### PR TITLE
実行引数にデータ時点を追加して出力日付を制御

### DIFF
--- a/build_json.py
+++ b/build_json.py
@@ -7,7 +7,7 @@ patiants_list = []
 patiants_summary_dic = {}
 main_summary_dic = {}
 
-with open('data/patients.csv') as csvfile:
+with open('data/patients.csv', 'r', encoding="utf-8") as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
         patiants_list.append(row)
@@ -36,7 +36,7 @@ for date in datelist:
 
 main_summary_dic = {}
 
-with open('data/main_summary.csv') as csvfile:
+with open('data/main_summary.csv', 'r', encoding="utf-8") as csvfile:
     reader = csv.reader(csvfile)
     for row in reader:
         main_summary_dic[row[0]] = int(row[1])

--- a/build_json.py
+++ b/build_json.py
@@ -1,11 +1,14 @@
 import csv
 import json
 from datetime import datetime, date, time, timedelta
-import sys
+import io, sys
 
 patiants_list = []
 patiants_summary_dic = {}
 main_summary_dic = {}
+
+# 引数を取得 異常系処理はしてないので注意
+args = sys.argv
 
 with open('data/patients.csv', 'r', encoding="utf-8") as csvfile:
     reader = csv.DictReader(csvfile)
@@ -16,7 +19,7 @@ with open('data/patients.csv', 'r', encoding="utf-8") as csvfile:
 
 # 日付のリストを生成
 strdt = datetime.strptime("2020-01-26", '%Y-%m-%d')  # 開始日
-enddt = datetime.now()  # 終了日
+enddt = datetime.strptime(args[1], '%Y-%m-%d')  # 終了日
 
 # 日付差の日数を算出（リストに最終日も含めたいので、＋１しています）
 days_num = (enddt - strdt).days + 1
@@ -93,4 +96,5 @@ data = {
     }
 }
 
-print(json.dumps(data))
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+print(json.dumps(data, indent=4, ensure_ascii=False))

--- a/pretty_json.py
+++ b/pretty_json.py
@@ -1,4 +1,5 @@
-import sys, json
+import io, sys, json
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 print(json.dumps(json.loads(sys.stdin.read()), indent=4, ensure_ascii=False))
 


### PR DESCRIPTION
- 実行引数にデータ時点を追加して出力日付を制御
- pretty_json.pyをパイプしなくても動作するように変更